### PR TITLE
remove show publically, add leaderboard

### DIFF
--- a/src/app/api/poll/leaderboard/route.ts
+++ b/src/app/api/poll/leaderboard/route.ts
@@ -14,11 +14,6 @@ export async function GET(req : NextRequest) {
         if (userid && d._id == userid) {
             newData.isUser = true;
         }
-        if (d.showNamePublically && (d.name?.length ?? 0) > 0) {
-            newData.joinedTitle = d.name + ", " + d.joinedTitle
-        } else {
-            newData.name = undefined
-        }
         cleanedData.push(newData)
      })
     

--- a/src/app/poll/dashboard/page.tsx
+++ b/src/app/poll/dashboard/page.tsx
@@ -35,7 +35,6 @@ export default async function Page() {
             qualifier: info.title?.qualifier ?? ''
         },
         email: info.email ?? '',
-        showNamePublically: info.showNamePublically ?? false
     }
     const cleanedLeaderboardData : LeaderboardRecord[] = []
     leaderboardData.forEach((d) => { 
@@ -45,14 +44,8 @@ export default async function Page() {
         if (userid && d._id === userid.value) {
             newData.isUser = true;
         }
-        if (d.showNamePublically && (d.name?.length ?? 0) > 0) {
-            newData.joinedTitle = d.name + ", " + d.joinedTitle
-        } else {
-            newData.name = undefined
-        }
         cleanedLeaderboardData.push(newData)
     })
-    console.log(cleanedLeaderboardData)
 
     return <>
         <DashTabs userQuestionData={questionData} userData={defined_info} staticLeaderboardData={cleanedLeaderboardData}/>

--- a/src/components/poll/dash/DashTabs.tsx
+++ b/src/components/poll/dash/DashTabs.tsx
@@ -1,12 +1,11 @@
 'use client'
 import { Concrete } from "$/lib/queries";
 import { LeaderboardRecord, UserRecord } from "$/lib/dashboard_queries"
-import { PollQuestion_t } from "$/types/documents";
-import React, { createContext, useEffect, useMemo, useState } from "react"
+import React, { createContext, useMemo, useState } from "react"
 import { UserQuestionInfo } from "./types";
 import PollEntry from "./PollEntry";
 import { UserPreferences } from "./UserPreferences";
-import { randomInRange, theme } from "@/poll/pollUtil";
+import { theme } from "@/poll/pollUtil";
 import { Leaderboard } from "./Leaderboard";
 
 export const UserContext = createContext<string>('')
@@ -68,18 +67,18 @@ export default function DashTabs({ userData, userQuestionData, staticLeaderboard
         },
         {
             index: 2,
-            listitem: <li className='pd__tabmenu__spacer'></li>
+            title: 'Leaderboard',
+            body: <Leaderboard leaderboardData={leaderboardData} setLeaderboardData={setLeaderboardData}/>
         },
         {
             index: 3,
+            listitem: <li className='pd__tabmenu__spacer'></li>
+        },
+        {
+            index: 4,
             title: 'Preferences',
             body: <UserPreferences userRecord={userRecord} setUserRecord={setUserRecord} originalRecord={originalUserData} setOriginalRecord={setOriginalUserData}/>
-        },/* 
-        {
-            index: 2,
-            title: 'Leaderboard',
-            body: <Leaderboard leaderboardData={leaderboardData} setLeaderboardData={setLeaderboardData}/>
-        }, */
+        } 
     ]
     
     return (
@@ -88,7 +87,7 @@ export default function DashTabs({ userData, userQuestionData, staticLeaderboard
             <UserContext.Provider value={userRecord._id}>
                 <menu className="pd__tabmenu">
                     {tabs.map((t, i) => 
-                        t.listitem? t.listitem : 
+                        t.listitem ? <React.Fragment key={i}>{t.listitem}</React.Fragment> : 
                         <li key={i} className={`pd__tabmenu__tab ${currentTab === t.index ? 'current' : ''}`} onClick={() => setCurrentTab(t.index)}>{t.title}</li>
                     )}
                 </menu>

--- a/src/components/poll/dash/Leaderboard.tsx
+++ b/src/components/poll/dash/Leaderboard.tsx
@@ -1,44 +1,60 @@
-import "R/src/components/poll-dash/styles/pollLeaderboard.scss"
+'use client'
+import "../styles/pollLeaderboard.scss"
 import { LeaderboardRecord, UserRecord } from "$/lib/dashboard_queries"
 import { Tooltip } from "react-tooltip"
+import { useState } from "react"
 
 const barcode = 'IIIIIIIIII'
 
 export function Leaderboard({ leaderboardData, setLeaderboardData } : { leaderboardData : LeaderboardRecord[], setLeaderboardData : (val : LeaderboardRecord[]) => void}) {
+    const [refreshing, setRefreshing] = useState(false)
+
+    async function refreshLeaderboardData() {
+        setRefreshing(true)
+        const response = await fetch('/api/poll/leaderboard')
+        const result : LeaderboardRecord[] = await response.json()
+
+        setLeaderboardData(result)
+        setRefreshing(false)
+    }
+
     return (
         <div className="pd__leaderboard">
             <div className="pd__leaderboard__header">
                 <h3>Leaderboard</h3>
-                <div>
-                    <button className="">Refresh Leaderboard</button>
+                <div className="pd__leaderboard__refresh">
+                    {refreshing && <span>Refreshing...</span>}
+                    <button className="pd__btn" onClick={refreshLeaderboardData}>Refresh Leaderboard</button>
                 </div>  
             </div>
-            <div className="pd__leaderboard__body">
-                <div className="leaderboard-table-row header">
-                    <span className="rank">Rank</span>
-                    <span className="user">User</span>
-                    <span className="score">Score</span>
-                </div>
-                <ol className="pd__leaderboard__body__entries">
-                {leaderboardData.map((rec, index) => (
-                    <li className={`leaderboard-table-row${rec.isUser ? ' me' : ''}`} key={index}>
-                        <span className="rank">#{index + 1}</span>
-                        <span className="user">
-                            {rec.joinedTitle 
-                                ? <span>{rec.joinedTitle}</span>
-                                : <span data-tooltip-id={`${index}-user`} className="barcode">{barcode}</span>
+            <table className="pd__leaderboard__table">
+                <thead>
+                    <tr>
+                        <th>Rank</th>
+                        <th>User</th>
+                        <th>Score</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {leaderboardData.map((rec, index) => (
+                        <tr className={`leaderboard-table-row${rec.isUser ? ' me' : ''}`} key={index}>
+                            <td className="rank">#{index + 1}</td>
+                            <td className="user">
+                                {rec.joinedTitle 
+                                    ? <span>{rec.joinedTitle}</span>
+                                    : <span data-tooltip-id={`${index}-user`} className="barcode">{barcode}</span>
+                                }
+                            </td>
+                            <td className="score">{rec.score}</td>
+                            {!rec.joinedTitle && 
+                                <Tooltip id={`${index}-user`} place="right" content="This resident of the Castle has not generated a title!"/>
                             }
-                        </span>
-                        <span className="score">{rec.score}</span>
-                        {!rec.joinedTitle && 
-                            <Tooltip id={`${index}-user`} place="right" content="This user has not generated a title or given a name for themselves!"/>
-                        }
-                    </li>
-                ))}
-                </ol>
-            </div>
-            <span className="pd__leaderboard__note">&quot;{barcode}&quot; indicates user has not generated a title or name.</span>
-            
+                        </tr>
+                    ))}
+                </tbody>
+            </table>
+
+            <span className="pd__leaderboard__note">&quot;{barcode}&quot; indicates user has not generated a title.</span>
         </div>
     )
 }

--- a/src/components/poll/dash/UserPreferences.tsx
+++ b/src/components/poll/dash/UserPreferences.tsx
@@ -5,8 +5,6 @@ import { UserRecord } from "$/lib/dashboard_queries"
 import { professionList, qualifierList } from "./types";
 import { randomInRange } from "@/poll/pollUtil";
 
-
-
 export function UserPreferences({ userRecord, setUserRecord, originalRecord, setOriginalRecord } : { userRecord : Concrete<UserRecord>, setUserRecord : (val : Concrete<UserRecord>) => void, originalRecord : Concrete<UserRecord>, setOriginalRecord : (val : Concrete<UserRecord>) => void}) {
     const [madeChanges, setMadeChanges] = useState(false)
     const [submitting, setSubmitting] = useState(false);
@@ -14,7 +12,6 @@ export function UserPreferences({ userRecord, setUserRecord, originalRecord, set
     useEffect(() => {
         if (userRecord.email !== originalRecord.email 
             || userRecord.isPolledDaily !== originalRecord.isPolledDaily 
-            || userRecord.showNamePublically !== originalRecord.showNamePublically
             || userRecord.name !== originalRecord.name
             || userRecord.title?.profession !== originalRecord.title?.profession
             || userRecord.title?.qualifier !== originalRecord.title?.qualifier) {
@@ -76,12 +73,7 @@ export function UserPreferences({ userRecord, setUserRecord, originalRecord, set
                 <div className="pd__preferences__field pd__preferences__field--checkbox">
                     <input type='checkbox' checked={userRecord.isPolledDaily} onChange={ (e) => setUserRecord({...userRecord, isPolledDaily: e.target.checked}) } id='daily-poll-checkbox'/>
                     <label htmlFor='daily-poll-checkbox'>I would like to receive daily polls at the above email address.</label>
-                </div>{/* 
-                <div className="pd__preferences__field pd__preferences__field--checkbox">
-                    <input type='checkbox' checked={userRecord.showNamePublically} onChange={ (e) => setUserRecord({...userRecord, showNamePublically: e.target.checked}) } id='show-name-checkbox'/>
-                    <label htmlFor='show-name-checkbox'>Display name <strong>{userRecord.name}</strong> publically in addition to title.</label>
                 </div>
- */}
             </div>
             {(madeChanges || message.length > 0) && 
                 <div className="pd__preferences__divider"/>

--- a/src/components/poll/styles/pollDashboard.scss
+++ b/src/components/poll/styles/pollDashboard.scss
@@ -19,6 +19,7 @@
         border-top: none;
         box-sizing: border-box;
         padding: .75rem .4rem;
+        margin-bottom: 2rem;
     }
     &__tabmenu {
         display: flex;
@@ -97,7 +98,7 @@
             --even-row: white;
             --header-row: #{$chefchaouenBlue};
             --header-row-text: #{$snow};
-            --leaderboard-hover-color: #{$blush};
+            --leaderboard-hover-background: #{$blush};
         }
     }
     .pe {
@@ -177,7 +178,7 @@
             --even-row: white;
             --header-row: #{$chefchaouenBlue};
             --header-row-text: #{$snow};
-            --leaderboard-hover-color: #{$blush};
+            --leaderboard-hover-background: #{$blush};
         }
     }
     .pe {
@@ -264,7 +265,7 @@
             --even-row: white;
             --header-row: #{$chefchaouenBlue};
             --header-row-text: #{$snow};
-            --leaderboard-hover-color: #{$blush};
+            --leaderboard-hover-background: #{$blush};
         }
     }
     .pe {
@@ -373,7 +374,7 @@
             --even-row: white;
             --header-row: #{$chefchaouenBlue};
             --header-row-text: #{$snow};
-            --leaderboard-hover-color: #{$blush};
+            --leaderboard-hover-background: #{$blush};
         }
     }
     .pe {
@@ -490,7 +491,7 @@
             --even-row: white;
             --header-row: #{$chefchaouenBlue};
             --header-row-text: #{$snow};
-            --leaderboard-hover-color: #{$blush};
+            --leaderboard-hover-background: #{$blush};
         }
     }
     .pe {
@@ -622,7 +623,7 @@
             --even-row: white;
             --header-row: #{$chefchaouenBlue};
             --header-row-text: #{$snow};
-            --leaderboard-hover-color: #{$blush};
+            --leaderboard-hover-background: #{$blush};
         }
     }
     .pe {
@@ -685,6 +686,7 @@
     }
 }
 .august-dark {
+    
     .pd {
         &__title {
             color: $white;
@@ -692,6 +694,18 @@
         &__body {
             background-color: $august_buttonSignup;
             border-color: $august_optionsItem;
+        }
+        &__btn {
+            background-color: $august_optionsItemFillBar;
+            color: $august_header;
+            padding: .2rem .5rem;
+            border: 2px solid $white;
+            font-weight: bold;
+            transition-duration: .2s;
+            cursor: pointer;
+            &:hover {
+                transform: scale(1.05);
+            }
         }
         &__tabmenu {
             &__tab {
@@ -748,13 +762,16 @@
         &__leaderboard {
             &__body {
             }
-            --me-background: #{$blush};
-            --me-text-color: #{$prussianBlue};
-            --odd-row: #{$uranianBlue};
-            --even-row: white;
-            --header-row: #{$chefchaouenBlue};
-            --header-row-text: #{$snow};
-            --leaderboard-hover-color: #{$blush};
+            --me-background: #{$august_optionsItem};
+            --me-text-color: #{black};
+            --odd-row: #{$august_header};
+            --even-row: #{$august_body};
+            --header-row: #{$august_optionsItem};
+            --header-row-text: #{black};
+            --body-row-text: #{white};
+            --surrounding-text-color: #{white};
+            --leaderboard-hover-background: #{$august_optionsItemFillBar};
+            --leaderboard-hover-text: #{black};
         }
     }
     .pe {

--- a/src/components/poll/styles/pollLeaderboard.scss
+++ b/src/components/poll/styles/pollLeaderboard.scss
@@ -9,12 +9,14 @@
             margin-bottom: 1.5rem;
             h3 {
                 margin: 0;
+                color: var(--surrounding-text-color);
             }
         }
         &__note {
             margin-top: 1rem;
             margin-left: 1rem;
             display: block;
+            color: var(--surrounding-text-color);
         }
         &__body {
             &__entries {
@@ -23,24 +25,65 @@
             }
             border: 2px solid;
             border-radius: 5px;
-        }        
+        }  
+        &__refresh {
+            display: flex;
+            flex-direction: row;
+            align-items: center;
+            gap: 1rem;
+            span {
+                color: var(--surrounding-text-color);
+
+                margin-left: .5rem;
+                text-transform: uppercase;
+                font-weight: bold;
+                font-size: .8rem;
+                font-family: 'Trebuchet MS', 'Lucida Sans Unicode', 'Lucida Grande', 'Lucida Sans', Arial, sans-serif;
+                animation-name: fade;
+                animation-duration: .8s;
+                animation-iteration-count: infinite;
+                animation-timing-function: linear;
+            
+                @keyframes fade {
+                    0% { opacity: 1; }
+                    50% { opacity: .2;}
+                    100% { opacity: 1;}
+                    
+                }
+            }
+        }      
         --header-col-odd: var(--header-row);
         --header-col-even: var(--header-row);
         --odd-row-odd-col: var(--odd-row);
         --odd-row-even-col: var(--odd-row);
         --even-row-odd-col: var(--even-row);
         --even-row-even-col: var(--even-row);    
+        &__table {
+            width: 100%;
+            background-color: slategray;
+            tbody {
+                width: 100%;
+                background-color: white;
+            }
+            thead th {
+                color: var(--header-row-text);
+                font-weight: bold;
+                &:nth-child(2n + 1) {
+                    background-color: var(--header-col-odd);
+                }
+                &:nth-child(2n) {
+                    background-color: var(--header-col-even);
+                }
 
+            }
+        }
     }
 }
 .leaderboard-table-row {
-    display: flex;
-    flex-direction: row;
-    > span {
+    > td {
+        border: none;
         padding: .5rem 1rem; 
-        &:hover {
-            background-color: var(--leaderboard-hover-color) !important;
-        }
+        color: var(--body-row-text);
         //cursor: cell;
         &:nth-child(2n + 1) {
             background-color: var(--odd-row-odd-col) ;
@@ -51,7 +94,6 @@
     }
     > .user {
         width: 75%;
-        border-right: 1px solid black;
     }
     > .score {
         width: 20%;
@@ -59,28 +101,16 @@
     > .rank {
         width: 6%;
         text-align: center;
-        border-right: 1px solid black;
     }
-    &.me > span {
-        background-color: var(--me-background) !important;
+    &.me > td {
+        background-color: var(--me-background);
         color: var(--me-text-color);
     }
-    &.header > span {
-        color: var(--header-row-text);
-        font-weight: bold;
-        &:nth-child(2n + 1) {
-            background-color: var(--header-col-odd);
-        }
-        &:nth-child(2n) {
-            background-color: var(--header-col-even);
-        }
-
-    }
     &:nth-child(2n) {
-        & > span:nth-child(2n + 1) {
+        & > td:nth-child(2n + 1) {
             background-color: var(--even-row-odd-col);
         }
-        & > span:nth-child(2n) {
+        & > td:nth-child(2n) {
             background-color: var(--even-row-even-col);
         }
     }

--- a/src/sanity/lib/dashboard_queries.ts
+++ b/src/sanity/lib/dashboard_queries.ts
@@ -4,16 +4,12 @@ export const leaderboardQuery = groq`
 *[_type == 'recipient'] { 
     "joinedTitle": title.profession + " " + title.qualifier, 
     "score": count(*[_type == "pollQuestion" && length(responses[length(listOfResponders[_ref == ^.^.^._id]) > 0]) > 0]),
-    name,
-    showNamePublically,
     _id
 } | order(score desc)
 `
 export type LeaderboardRecord = {
     joinedTitle? : string,
     score : number
-    showNamePublically? : string
-    name? : string
     _id? : string
     isUser : undefined | true
 }
@@ -40,8 +36,7 @@ export const user_dashboard_information = groq`
     title {
         profession,
         qualifier
-    },
-    showNamePublically
+    }
 }`
 export type UserRecord = {
     _id : string
@@ -52,5 +47,4 @@ export type UserRecord = {
         profession? : string
         qualifier? : string
     }
-    showNamePublically? : boolean
 }

--- a/src/sanity/schemaTypes/recipient.ts
+++ b/src/sanity/schemaTypes/recipient.ts
@@ -20,12 +20,6 @@ export default {
             default: false
         },
         {
-            name: "showNamePublically",
-            title: "Show name on leaderboard?",
-            type: "boolean",
-            default: false
-        },
-        {
             name: 'name',
             title: 'Name',
             type: 'string'


### PR DESCRIPTION
Closes issue #9. 

Add the leaderboard, finally. Most of this is just redoing the markup to use `<table>` tags (semantic HTML, woohoo!) and letting the styling that was already there do most of the heavy listing.

I'll leave a few comments for things to take note of. There's plenty of junk CSS in the copy-paste from month to month, exacerbated by leaderboard styles that weren't used. I renamed a css variable that was copy-pasted everywhere, so that shows up in the diff; leaving them for now bu they could be removed if we felt strongly about it. CSS Overhaul Soon (TM)